### PR TITLE
Fix IllegalArgumentException

### DIFF
--- a/jobscheduler/src/main/java/me/tatarka/support/internal/JobSchedulerLollipopDelegate.java
+++ b/jobscheduler/src/main/java/me/tatarka/support/internal/JobSchedulerLollipopDelegate.java
@@ -59,13 +59,14 @@ public class JobSchedulerLollipopDelegate extends JobScheduler {
         builder.setExtras((android.os.PersistableBundle) job.getExtras().getRealBundle());
         builder.setRequiresCharging(job.isRequireCharging());
         builder.setRequiresDeviceIdle(job.isRequireDeviceIdle());
-        builder.setRequiredNetworkType(job.getNetworkType());
-
-        if (job.getMinLatencyMillis() != 0) {
+        builder.setRequiredNetworkType(job.getNetworkType()); 
+        builder.setPersisted(job.isPersisted());  
+        
+        if (job.getMinLatencyMillis() != 0 && !job.isPeriodic()) {
             builder.setMinimumLatency(job.getMinLatencyMillis());
         }
 
-        if (job.getMaxExecutionDelayMillis() != 0) {
+        if (job.getMaxExecutionDelayMillis() != 0 && !job.isPeriodic()) {
             builder.setOverrideDeadline(job.getMaxExecutionDelayMillis());
         }
 
@@ -73,24 +74,27 @@ public class JobSchedulerLollipopDelegate extends JobScheduler {
             builder.setPeriodic(job.getIntervalMillis());
         }
 
-        builder.setPersisted(job.isPersisted());
-        builder.setBackoffCriteria(job.getInitialBackoffMillis(), job.getBackoffPolicy());
+        if (!job.isRequireDeviceIdle()) {
+            builder.setBackoffCriteria(job.getInitialBackoffMillis(), job.getBackoffPolicy());
+        }
 
         return builder.build();
     }
 
     private static JobInfo convertFromJobInfo(android.app.job.JobInfo job) {
         JobInfo.Builder builder = new JobInfo.Builder(job.getId(), job.getService());
+        
         builder.setExtras(new PersistableBundle(job.getExtras()));
         builder.setRequiresCharging(job.isRequireCharging());
         builder.setRequiresDeviceIdle(job.isRequireDeviceIdle());
         builder.setRequiredNetworkType(job.getNetworkType());
+        builder.setPersisted(job.isPersisted());
 
-        if (job.getMinLatencyMillis() != 0) {
+        if (job.getMinLatencyMillis() != 0 && !job.isPeriodic()) {
             builder.setMinimumLatency(job.getMinLatencyMillis());
         }
 
-        if (job.getMaxExecutionDelayMillis() != 0) {
+        if (job.getMaxExecutionDelayMillis() != 0 && !job.isPeriodic()) {
             builder.setOverrideDeadline(job.getMaxExecutionDelayMillis());
         }
 
@@ -98,8 +102,9 @@ public class JobSchedulerLollipopDelegate extends JobScheduler {
             builder.setPeriodic(job.getIntervalMillis());
         }
 
-        builder.setPersisted(job.isPersisted());
-        builder.setBackoffCriteria(job.getInitialBackoffMillis(), job.getBackoffPolicy());
+        if (!job.isRequireDeviceIdle()) {
+            builder.setBackoffCriteria(job.getInitialBackoffMillis(), job.getBackoffPolicy());
+        }
 
         return builder.build();
     }


### PR DESCRIPTION
Hello.

The following code produces an `IllegalArgumentException` on Lollipop devices.

``` java
JobScheduler.getInstance(context).schedule(new JobInfo.Builder(JOB_SYNC, new ComponentName(context, SyncService.class))
                .setPeriodic(TimeUnit.DAYS.toMillis(1))
                .setRequiresDeviceIdle(true)
                .setRequiresCharging(false)
                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
                .setPersisted(true)
                .build()
);
```

Stack trace:

```
java.lang.IllegalArgumentException: An idle mode job will not respect any back-off policy, so calling setBackoffCriteria with setRequiresDeviceIdle is an error.
            at android.app.job.JobInfo$Builder.build(JobInfo.java:465)
            at me.tatarka.support.internal.JobSchedulerLollipopDelegate.convertJobInfo(JobSchedulerLollipopDelegate.java:79)
            at me.tatarka.support.internal.JobSchedulerLollipopDelegate.schedule(JobSchedulerLollipopDelegate.java:53)
```

The reason is that `JobInfo.Builder` documentation [explicitly prohibits](https://developer.android.com/reference/android/app/job/JobInfo.Builder.html#setBackoffCriteria%28long, int%29) to use `setRequiresDeviceIdle(true)` and `setBackoffCriteria` at the same time.

```
Note that trying to set a backoff criteria for a job with setRequiresDeviceIdle(boolean) will throw an exception when you call build(). 
```

The code above uses only `setRequiresDeviceIdle(true)` so it's totaly correct, but `JobSchedulerLollipopDelegate. convertJobInfo` and `JobSchedulerLollipopDelegate. convertFromJobInfo` fail to follow the restrictions.
